### PR TITLE
[12.0][FIX] hw_printer_network: cors errors

### DIFF
--- a/hw_printer_network/controllers/hw_printer_network_controller.py
+++ b/hw_printer_network/controllers/hw_printer_network_controller.py
@@ -19,7 +19,7 @@ try:
     from odoo.addons.hw_escpos.controllers.main import EscposProxy
     from odoo.addons.hw_escpos.controllers.main import EscposDriver
     from odoo.addons.hw_escpos.escpos.printer import Network
-    import odoo.addons.hw_proxy.controllers.main as hw_proxy
+    from odoo.addons.hw_proxy.controllers import main as hw_proxy
 except ImportError:
     EscposProxy = object
     EscposDriver = object
@@ -181,7 +181,7 @@ hw_proxy.drivers["escpos_network"] = network_driver
 network_driver.push_task("printstatus")
 
 
-class UpdatedEscposProxy(EscposProxy):
+class UpdatedEscposProxy(hw_proxy.Proxy):
     @http.route("/hw_proxy/print_xml_receipt", type="json", auth="none", cors="*")
     def print_xml_receipt(self, receipt, proxy=None):
         if proxy:


### PR DESCRIPTION
I've solved the CORS error, but when printing a receipt I now get the following error : `ESC/POS Error: a bytes-like object is required, not 'str'`

The solution at the end of [this issue](https://github.com/odoo/odoo/issues/25607) works but it implies to modify `hw_escpos`. I don't think it's the proper workaround.

I've tested both `pos_printer_network` and `hw_printer_network` in their original version (from https://github.com/itpp-labs/pos-addons/tree/12.0), and I encountered the same problems: 
1) CORS error
2) ESC/POS Error: a bytes-like object is required, not 'str'

So far, no other solution than to modify `printer.py` in `hw_escpos`: 
```python
def _raw(self, msg):
    if type(msg) == str:
        msg = bytes(msg, 'UTF-8')
    self.device.send(msg)
```
